### PR TITLE
Add GitHub Release workflow

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,53 @@
+name: Release WordPress Plugin
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Zip WordPress Plugin Folder
+      run: zip -r Timeline-WP-${{ github.ref_name }}.zip ./Timeline-WP/
+
+    - name: Upload Plugin Zip as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Timeline-WP-${{ github.ref_name }}
+        path: ./Timeline-WP-${{ github.ref_name }}.zip
+
+  create-release:
+    needs: [prepare-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download Plugin Zip artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: Timeline-WP-${{ github.ref_name }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Timeline-WP ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./Timeline-WP-${{ github.ref_name }}.zip
+          asset_name: Timeline-WP-${{ github.ref_name }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           release_name: Timeline-WP ${{ github.ref_name }}
-          draft: false
-          prerelease: false
+          draft: true
+          prerelease: true
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
This pull request adds a GitHub Release workflow that automates the process of creating a release for the WordPress Plugin. The workflow includes steps to zip the plugin folder, upload it as an artifact, create a release, and upload the release asset. This will make it easier to distribute the plugin to users.